### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -406,8 +406,8 @@ python -c "import autogen; print(f'AutoGen version: {autogen.__version__}')"
 
 # Solution
 # Ensure AutoGen v0.4+ is installed
-pip install "pyautogen>=0.4.0"
-pip install --upgrade pyautogen
+pip install "ag2>=0.4.0"
+pip install --upgrade ag2
 
 # Verify installation
 python -c "
@@ -652,7 +652,7 @@ def collect_diagnostic_info():
         "packages": {
             pkg.project_name: pkg.version 
             for pkg in pkg_resources.working_set
-            if pkg.project_name in ['pyautogen', 'openai', 'aiohttp']
+            if pkg.project_name in ['ag2', 'openai', 'aiohttp']
         },
         "environment": {
             "openai_api_key_set": bool(os.getenv('OPENAI_API_KEY')),


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the troubleshooting guide to reference the new package name "ag2" instead of "pyautogen" in installation and diagnostic commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->